### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ If these files are not found, you will receive the following error when running 
 
 ![following error when running your application](/images/resource_error.jpg)
 
-Note: If your application wants to suppress the above message box, but still receive an error return code, your application should issue a call to the API function **DTWAIN_SysInitializeNoBlocking** instead of **DTWAIN_SysInitialize** (see the examples below -- simply change **DTWAIN_SysInitialize** to **DTWAIN_SysInitializeNoBlocking**).  The error return code will be **-1051** if DTWAIN_SysInitializeNoBlocking detects an error initializing the library, and 0 if there is no error and the initialization was successful.
+Note: If your application wants to suppress the above message box, but still receive an error return code, your application should issue a call to the API function **DTWAIN_SysInitializeNoBlocking** instead of **DTWAIN_SysInitialize** (see the examples below -- simply change **DTWAIN_SysInitialize** to **DTWAIN_SysInitializeNoBlocking**).  If **DTWAIN_SysInitializeNoBlocking** returns a 0 or null handle, a subsequent call to **DTWAIN_GetLastError** will return **-1051**, indicating that the DTWAIN resources were not loaded.
 
 Note: Make sure that you use the latest version of the text resources.  If you are not using a version of 
 In addition, there are optional string resource files available.  Here are a list of those files:


### PR DESCRIPTION
Add that a call to DTWAIN_GetLastError should be made if DTWAIN_SysInitialize or DTWAIN_SysInitializeNoBlocking returns null.